### PR TITLE
Fix syntax highlighting in readme.md + feedback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Leverage performance profiling with your browser tools with the [tracing crate](
 For the simplest out of the box set-up, you can simply set `tracing_wasm` as your default tracing Subscriber in wasm_bindgen(start)
 
 We have this declared in our `./src/lib.rs`
-```rs
 
+```rust
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), JsValue> {
     // print pretty errors in wasm https://github.com/rustwasm/console_error_panic_hook
@@ -36,5 +36,4 @@ pub fn start() -> Result<(), JsValue> {
 
     Ok(())
 }
-
 ```


### PR DESCRIPTION
The syntax highlighting was not showing on Github so I fixed that.

Thank you for making `tracing-wasm`. I don't use it for performance profiling yet but it is really useful for getting nicely formatted logs without any boilerplate.