### PR TITLE
Guard `performance.*` with `report_logs_in_timings`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,31 +149,35 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WASMLayer {
     }
     /// doc: Notifies this layer that a span with the given ID was entered.
     fn on_enter(&self, id: &tracing::Id, _ctx: Context<'_, S>) {
-        mark(&mark_name(id));
+        if self.config.report_logs_in_timings {
+            mark(&mark_name(id));
+        }
     }
     /// doc: Notifies this layer that the span with the given ID was exited.
     fn on_exit(&self, id: &tracing::Id, ctx: Context<'_, S>) {
-        if let Some(span_ref) = ctx.span(id) {
-            let meta = span_ref.metadata();
-            if let Some(debug_record) = span_ref.extensions().get::<StringRecorder>() {
-                measure(
-                    &format!(
-                        "\"{}\" {} {}",
-                        meta.name(),
-                        meta.module_path().unwrap_or("..."),
-                        debug_record,
-                    ),
-                    &mark_name(id),
-                )
-            } else {
-                measure(
-                    &format!(
-                        "\"{}\" {}",
-                        meta.name(),
-                        meta.module_path().unwrap_or("..."),
-                    ),
-                    &mark_name(id),
-                )
+        if self.config.report_logs_in_timings {
+            if let Some(span_ref) = ctx.span(id) {
+                let meta = span_ref.metadata();
+                if let Some(debug_record) = span_ref.extensions().get::<StringRecorder>() {
+                    measure(
+                        &format!(
+                            "\"{}\" {} {}",
+                            meta.name(),
+                            meta.module_path().unwrap_or("..."),
+                            debug_record,
+                        ),
+                        &mark_name(id),
+                    )
+                } else {
+                    measure(
+                        &format!(
+                            "\"{}\" {}",
+                            meta.name(),
+                            meta.module_path().unwrap_or("..."),
+                        ),
+                        &mark_name(id),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
I'm not sure if you intend for this library to be used outside of browsers. See #3 for that question. If so, currently, `tracing-wasm` doesn't work in environments where the global `performance` object is not available. E.g.:

- nodejs exports it as `perf_hooks.performance`, not as a global `peformance` object.

- cloudflare workers have a limited subset of global objects which does not include `performance` at all.

`WASMLayerConfig` allows opt-out of the performance timing APIs with the `report_logs_in_timings` option, but it was not previously being checked before some usage of `performance.mark` and `performance.measure`. This patch guards those calls against the config option.