### PR TITLE
WIP: Builder pattern for WASMLayerConfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod test {
                 report_logs_in_timings: true,
                 report_logs_in_console: true,
                 use_console_color: true,
-                level: tracing::Level::TRACE,
+                max_level: tracing::Level::TRACE,
             }
         )
     }
@@ -94,17 +94,17 @@ mod test {
 
         let config = builder.build();
 
-        assert_eq!(config.level, tracing::Level::TRACE);
+        assert_eq!(config.max_level, tracing::Level::TRACE);
     }
 
     #[test]
     fn test_set_config_log_level_warn() {
         let mut builder = WASMLayerConfigBuilder::new();
-        builder.set_level(tracing::Level::WARN);
+        builder.set_max_level(tracing::Level::WARN);
 
         let config = builder.build();
 
-        assert_eq!(config.level, tracing::Level::WARN);
+        assert_eq!(config.max_level, tracing::Level::WARN);
     }
 }
 
@@ -122,7 +122,7 @@ pub struct WASMLayerConfigBuilder {
     /// Only relevant if report_logs_in_console is true, this will use color style strings in the console.
     use_console_color: bool,
     /// Log events will be reported from this level -- Default is ALL (TRACE)
-    level: tracing::Level
+    max_level: tracing::Level
 }
 
 impl WASMLayerConfigBuilder {
@@ -139,12 +139,12 @@ impl WASMLayerConfigBuilder {
         self
     }
 
-    /// Set the minimal level on which events should be displayed
-    pub fn set_level(
+    /// Set the maximal level on which events should be displayed
+    pub fn set_max_level(
         &mut self,
-        level: tracing::Level,
+        max_level: tracing::Level,
     ) -> &mut WASMLayerConfigBuilder {
-        self.level = level;
+        self.max_level = max_level;
         self
     }
 
@@ -177,7 +177,7 @@ impl WASMLayerConfigBuilder {
             report_logs_in_timings: self.report_logs_in_timings,
             report_logs_in_console: self.report_logs_in_console,
             use_console_color: self.use_console_color,
-            level: self.level.clone(),
+            max_level: self.max_level.clone(),
         }
     }
 }
@@ -188,7 +188,7 @@ impl Default for WASMLayerConfigBuilder {
             report_logs_in_timings: true,
             report_logs_in_console: true,
             use_console_color: true,
-            level: tracing::Level::TRACE,
+            max_level: tracing::Level::TRACE,
         }
     }
 }
@@ -198,7 +198,7 @@ pub struct WASMLayerConfig {
     report_logs_in_timings: bool,
     report_logs_in_console: bool,
     use_console_color: bool,
-    level: tracing::Level
+    max_level: tracing::Level
 }
 
 impl core::default::Default for WASMLayerConfig {
@@ -207,7 +207,7 @@ impl core::default::Default for WASMLayerConfig {
             report_logs_in_timings: true,
             report_logs_in_console: true,
             use_console_color: true,
-            level: tracing::Level::TRACE
+            max_level: tracing::Level::TRACE
         }
     }
 }
@@ -240,7 +240,7 @@ fn mark_name(id: &tracing::Id) -> String {
 impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WASMLayer {
     fn enabled(&self, metadata: &tracing::Metadata<'_>, _: Context<'_, S>) -> bool {
         let level = metadata.level();
-        level <= &self.config.level
+        level <= &self.config.max_level
     }
 
     fn new_span(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,147 @@ extern "C" {
     fn log4(message1: &str, message2: &str, message3: &str, message4: &str);
 }
 
-pub struct WASMLayerConfig {
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_default_built_config() {
+        let builder = WASMLayerConfigBuilder::new();
+
+        let config = builder.build();
+
+        assert_eq!(
+            config,
+            WASMLayerConfig {
+                report_logs_in_timings: true,
+                report_logs_in_console: true,
+                use_console_color: true,
+            }
+        )
+    }
+
+    #[test]
+    fn test_set_report_logs_in_timings() {
+        let mut builder = WASMLayerConfigBuilder::new();
+        builder.set_report_logs_in_timings(false);
+
+        let config = builder.build();
+
+        assert_eq!(config.report_logs_in_timings, false);
+    }
+
+    #[test]
+    fn test_set_console_config_no_reporting() {
+        let mut builder = WASMLayerConfigBuilder::new();
+        builder.set_console_config(ConsoleConfig::NoReporting);
+
+        let config = builder.build();
+
+        assert_eq!(config.report_logs_in_console, false);
+        assert_eq!(config.use_console_color, false);
+    }
+
+    #[test]
+    fn test_set_console_config_without_color() {
+        let mut builder = WASMLayerConfigBuilder::new();
+        builder.set_console_config(ConsoleConfig::ReportWithoutConsoleColor);
+
+        let config = builder.build();
+
+        assert_eq!(config.report_logs_in_console, true);
+        assert_eq!(config.use_console_color, false);
+    }
+
+    #[test]
+    fn test_set_console_config_with_color() {
+        let mut builder = WASMLayerConfigBuilder::new();
+        builder.set_console_config(ConsoleConfig::ReportWithConsoleColor);
+
+        let config = builder.build();
+
+        assert_eq!(config.report_logs_in_console, true);
+        assert_eq!(config.use_console_color, true);
+    }
+}
+
+pub enum ConsoleConfig {
+    NoReporting,
+    ReportWithoutConsoleColor,
+    ReportWithConsoleColor,
+}
+
+pub struct WASMLayerConfigBuilder {
     /// Log events will be marked and measured so they appear in performance Timings
-    pub report_logs_in_timings: bool,
+    report_logs_in_timings: bool,
     /// Log events will be logged to the browser console
-    pub report_logs_in_console: bool,
+    report_logs_in_console: bool,
     /// Only relevant if report_logs_in_console is true, this will use color style strings in the console.
-    pub use_console_color: bool,
+    use_console_color: bool,
+}
+
+impl WASMLayerConfigBuilder {
+    pub fn new() -> WASMLayerConfigBuilder {
+        WASMLayerConfigBuilder::default()
+    }
+
+    /// Set whether events should appear in performance Timings
+    pub fn set_report_logs_in_timings(
+        &mut self,
+        report_logs_in_timings: bool,
+    ) -> &mut WASMLayerConfigBuilder {
+        self.report_logs_in_timings = report_logs_in_timings;
+        self
+    }
+
+    /// Set if and how events should be displayed in the browser console
+    pub fn set_console_config(
+        &mut self,
+        console_config: ConsoleConfig,
+    ) -> &mut WASMLayerConfigBuilder {
+        match console_config {
+            ConsoleConfig::NoReporting => {
+                self.report_logs_in_console = false;
+                self.use_console_color = false;
+            }
+            ConsoleConfig::ReportWithoutConsoleColor => {
+                self.report_logs_in_console = true;
+                self.use_console_color = false;
+            }
+            ConsoleConfig::ReportWithConsoleColor => {
+                self.report_logs_in_console = true;
+                self.use_console_color = true;
+            }
+        }
+
+        self
+    }
+
+    /// Build the WASMLayerConfig
+    pub fn build(&self) -> WASMLayerConfig {
+        WASMLayerConfig {
+            report_logs_in_timings: self.report_logs_in_timings,
+            report_logs_in_console: self.report_logs_in_console,
+            use_console_color: self.use_console_color,
+        }
+    }
+}
+
+impl Default for WASMLayerConfigBuilder {
+    fn default() -> WASMLayerConfigBuilder {
+        WASMLayerConfigBuilder {
+            report_logs_in_timings: true,
+            report_logs_in_console: true,
+            use_console_color: true,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct WASMLayerConfig {
+    report_logs_in_timings: bool,
+    report_logs_in_console: bool,
+    use_console_color: bool,
 }
 
 impl core::default::Default for WASMLayerConfig {


### PR DESCRIPTION
This is a follow on from #2 

It's an approach to building `WASMLayerConfig` via a non-consuming builder (https://rust-lang.github.io/api-guidelines/type-safety.html?#builders-enable-construction-of-complex-values-c-builder). It's definitely not complete or documented but I was curious how it would feel to use something like this.

I introduced a new ConsoleConfig enum because the dependent nature of `report_log_in_console` and `use_console_color` make me uncomfortable. There may be a better way to represent this.

There's some visibility modifiers that probably need resolved as well.

The builder adds a bit of overhead in comparison to a simple struct with setters, but provides some more immutability guarantees on the final product I suppose. Let me know your thoughts and whether I should pursue this to the end or pick another direction.