### PR TITLE
Use native console levels.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,31 @@ extern "C" {
     fn mark(a: &str);
     #[wasm_bindgen(js_namespace = performance)]
     fn measure(name: &str, startMark: &str);
+
     #[wasm_bindgen(js_namespace = console, js_name = log)]
     fn log1(message: &str);
     #[wasm_bindgen(js_namespace = console, js_name = log)]
-    fn log2(message1: &str, message2: &str);
-    #[wasm_bindgen(js_namespace = console, js_name = log)]
-    fn log3(message1: &str, message2: &str, message3: &str);
-    #[wasm_bindgen(js_namespace = console, js_name = log)]
     fn log4(message1: &str, message2: &str, message3: &str, message4: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = debug)]
+    fn debug1(message: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = debug)]
+    fn debug4(message1: &str, message2: &str, message3: &str, message4: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = info)]
+    fn info1(message: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = info)]
+    fn info4(message1: &str, message2: &str, message3: &str, message4: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn warn1(message: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn warn4(message1: &str, message2: &str, message3: &str, message4: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    fn error1(message: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    fn error4(message1: &str, message2: &str, message3: &str, message4: &str);
 }
 
 pub struct WASMLayerConfig {
@@ -122,7 +139,14 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WASMLayer {
                         "color: inherit",
                     );
                 } else {
-                    log1(&format!("{} {}{}", level, origin, recorder));
+                    let output = format!("{}{}", origin, recorder);
+                    match *level {
+                        tracing::Level::TRACE => debug1(&output),
+                        tracing::Level::DEBUG => debug1(&output),
+                        tracing::Level::INFO => info1(&output),
+                        tracing::Level::WARN => warn1(&output),
+                        tracing::Level::ERROR => error1(&output),
+                    }
                 }
             }
             if self.config.report_logs_in_timings {


### PR DESCRIPTION
Allows using native devtools controls for choosing what shows up, inheriting coloring from levels.

Open questions:

* should this be another config flag instead of piggy-backing on the "use colors" flag? should it be the only option instead? (wasm-bindgen-test is rather unhappy with the css, i'll note)
* should the "native console" levels do anything different with TRACE level events? should the console include trace-level events at all?
* should the native console levels still include the level substring? most browsers do styling of those differently so we could maybe save some horizontal space by omitting them (as it is in this PR)