### PR TITLE
Add option to add timestamps to the log output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+Cargo.lock
 
 **/.DS_Store
 **/Thumbs.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rayon = {version = "1.5", optional = true}
 tracing = {version = "0.1", features = ["attributes"], default-features = false}
 tracing-subscriber = {version = "0.2", features = ["registry"], default-features = false}
 wasm-bindgen = {version = "0.2"}
+chrono = { version = "^0.4", features = ["wasmbind"] }
 
 [features]
 mark-with-rayon-thread-index = ["rayon"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,14 +324,14 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WASMLayer {
                     .unwrap_or_default();
 
                 let timestamp = if self.config.log_time {
-                    chrono::Local::now().format("%a %d %T%.f").to_string()
+                    chrono::Local::now().format("%a %d %T%.f ").to_string()
                 } else {
                     String::new()
                 };
                 if self.config.use_console_color {
                     log4(
                         format!(
-                            "{} %c{}%c {}{}%c{}",
+                            "{}%c{}%c {}{}%c{}",
                             timestamp,
                             level,
                             origin,
@@ -350,7 +350,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WASMLayer {
                     );
                 } else {
                     log1(format!(
-                        "{} {} {}{} {}",
+                        "{}{} {}{} {}",
                         timestamp,
                         level,
                         origin,


### PR DESCRIPTION
The timestamps currently have a fixed formatting, but it should be fine for most cases and matches the default format in tracing.

It should be pretty easy to add configuration for this later on but I favored simplicity for now.